### PR TITLE
Security Hardening & Graph Traversal Enhancements

### DIFF
--- a/crates/semantic-engine/README.md
+++ b/crates/semantic-engine/README.md
@@ -33,6 +33,8 @@ It is designed to work seamlessly with **OpenClaw** and other agentic frameworks
 - **HuggingFace API Integration**: High-performance embeddings without local GPU/CPU heavy lifting
 - **High Performance**: Written in Rust with async I/O and efficient HNSW indexing
 - **Persistent Storage**: Automatic persistence with namespace-specific storage paths
+- **Granular Security**: Token-based authorization for Read, Write, Delete, and Reason operations.
+- **Robust MCP**: Strict JSON Schema validation for all Model Context Protocol tool calls.
 
 ## 📦 Installation
 
@@ -217,7 +219,7 @@ The `SemanticEngine` service provides the following RPC methods:
 | Method                | Request               | Response            | Description                            |
 | --------------------- | --------------------- | ------------------- | -------------------------------------- |
 | `IngestTriples`       | `IngestRequest`       | `IngestResponse`    | Add RDF triples to the graph           |
-| `GetNeighbors`        | `NodeRequest`         | `NeighborResponse`  | Graph traversal (get connected nodes)  |
+| `GetNeighbors`        | `NodeRequest`         | `NeighborResponse`  | Graph traversal (supports edge & type filters) |
 | `Search`              | `SearchRequest`       | `SearchResponse`    | Legacy vector search                   |
 | `ResolveId`           | `ResolveRequest`      | `ResolveResponse`   | Resolve URI string to internal node ID |
 | `GetAllTriples`       | `EmptyRequest`        | `TriplesResponse`   | Retrieve all triples from a namespace  |
@@ -230,7 +232,8 @@ The `SemanticEngine` service provides the following RPC methods:
 
 ### MCP Tools
 
-When running in `--mcp` mode, the following tools are exposed:
+When running in `--mcp` mode, the engine exposes a rich set of tools via `tools/list` and `tools/call`.
+All tool inputs are strictly validated against their JSON Schema definitions.
 
 #### `query_graph`
 
@@ -271,6 +274,17 @@ Execute a SPARQL query on the knowledge graph.
   "namespace": "string (default: robin_os)"
 }
 ```
+
+### Security & Authorization
+
+Synapse implements a token-based authorization system. When using gRPC, tokens are extracted from the `Authorization: Bearer <token>` header.
+Permissions are defined via the `SYNAPSE_AUTH_TOKENS` environment variable (JSON format).
+
+Supported permissions:
+- `read`: Query data (`GetNeighbors`, `Search`, `SparqlQuery`, etc.)
+- `write`: Ingest data (`IngestTriples`, `IngestFile`)
+- `delete`: Delete data (`DeleteNamespaceData`)
+- `reason`: Trigger reasoning (`ApplyReasoning`)
 
 ## 🏗️ Architecture
 

--- a/crates/semantic-engine/proto/semantic_engine.proto
+++ b/crates/semantic-engine/proto/semantic_engine.proto
@@ -84,6 +84,7 @@ message NodeRequest {
     string edge_filter = 5;     // Optional: filter by edge type (predicate)
     uint32 limit_per_layer = 6; // Max neighbors per depth level (0 = unlimited)
     string scoring_strategy = 7;// "default" or "degree" (penalize super-nodes)
+    string node_type_filter = 8; // Optional: filter neighbors by rdf:type
 }
 
 message NeighborResponse {

--- a/crates/semantic-engine/src/main.rs
+++ b/crates/semantic-engine/src/main.rs
@@ -20,6 +20,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("Synapse-MCP starting (stdio mode)...");
         run_mcp_stdio(Arc::new(engine)).await?;
     } else {
+        println!(
+            r#"
+
+  _________.__. ____ _____  ______  ______ ____
+ /  ___<   |  |/    \\__  \ \____ \/  ___// __ \
+ \___ \ \___  |   |  \/ __ \|  |_> >___ \\  ___/
+/____  >/ ____|___|  (____  /   __/____  >\___  >
+     \/ \/         \/     \/|__|       \/     \/
+"#
+        );
         let addr = "[::1]:50051".parse()?;
         println!("🚀 Synapse (ex-Grafoso) listening on {}", addr);
         println!("Storage Path: {}", storage_path);

--- a/crates/semantic-engine/tests/test_features.rs
+++ b/crates/semantic-engine/tests/test_features.rs
@@ -1,0 +1,88 @@
+use synapse_core::server::{MySemanticEngine, proto::{NodeRequest, IngestRequest, Triple}};
+use synapse_core::server::proto::semantic_engine_server::SemanticEngine;
+use tonic::Request;
+use std::env;
+
+#[tokio::test]
+async fn test_node_type_filter() {
+    env::set_var("MOCK_EMBEDDINGS", "true");
+    let storage_path = "/tmp/synapse_test_filter";
+    let _ = std::fs::remove_dir_all(storage_path);
+
+    let engine = MySemanticEngine::new(storage_path);
+    let namespace = "default";
+
+    // Graph:
+    // A -> B (Type: Person)
+    // A -> C (Type: Bot)
+    let triples = vec![
+        Triple { subject: "A".into(), predicate: "knows".into(), object: "B".into(), ..Default::default() },
+        Triple { subject: "A".into(), predicate: "knows".into(), object: "C".into(), ..Default::default() },
+        Triple { subject: "B".into(), predicate: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".into(), object: "Person".into(), ..Default::default() },
+        Triple { subject: "C".into(), predicate: "http://www.w3.org/1999/02/22-rdf-syntax-ns#type".into(), object: "Bot".into(), ..Default::default() },
+    ];
+
+    let req = Request::new(IngestRequest { triples, namespace: namespace.into() });
+    engine.ingest_triples(req).await.unwrap();
+
+    let store = engine.get_store(namespace).unwrap();
+    let a_id = store.get_or_create_id("http://synapse.os/A");
+
+    // Filter for Person
+    let req_filter = Request::new(NodeRequest {
+        node_id: a_id,
+        namespace: namespace.into(),
+        direction: "outgoing".into(),
+        depth: 1,
+        edge_filter: "".into(),
+        limit_per_layer: 0,
+        scoring_strategy: "default".into(),
+        node_type_filter: "http://synapse.os/Person".into(), // B should match
+    });
+
+    let resp = engine.get_neighbors(req_filter).await.unwrap().into_inner();
+    let neighbors = resp.neighbors;
+
+    println!("Neighbors: {:?}", neighbors);
+    assert_eq!(neighbors.len(), 1);
+    assert!(neighbors[0].uri.contains("B"));
+}
+
+#[tokio::test]
+async fn test_auth_read_fail() {
+    let storage_path = "/tmp/synapse_test_auth";
+    let _ = std::fs::remove_dir_all(storage_path);
+
+    // Set auth tokens
+    env::set_var("SYNAPSE_AUTH_TOKENS", r#"
+    {
+        "user_read": {
+            "namespaces": ["default"],
+            "permissions": {"read": true, "write": false, "delete": false, "reason": false}
+        },
+        "user_none": {
+             "namespaces": ["default"],
+             "permissions": {"read": false, "write": false, "delete": false, "reason": false}
+        }
+    }
+    "#);
+
+    // Force reload of auth by creating new engine (auth loads from env in constructor)
+    let engine = MySemanticEngine::new(storage_path);
+    let namespace = "default";
+
+    // Request with valid read token
+    let mut req_good = Request::new(synapse_core::server::proto::EmptyRequest { namespace: namespace.into() });
+    req_good.metadata_mut().insert("authorization", "Bearer user_read".parse().unwrap());
+
+    let res = engine.get_all_triples(req_good).await;
+    assert!(res.is_ok(), "Read should succeed with read permission");
+
+    // Request with no permission
+    let mut req_bad = Request::new(synapse_core::server::proto::EmptyRequest { namespace: namespace.into() });
+    req_bad.metadata_mut().insert("authorization", "Bearer user_none".parse().unwrap());
+
+    let res = engine.get_all_triples(req_bad).await;
+    assert!(res.is_err(), "Read should fail with no permission");
+    assert_eq!(res.err().unwrap().code(), tonic::Code::PermissionDenied);
+}


### PR DESCRIPTION
This PR addresses the "Future Work" items from the Synapse paper.

1.  **Security**: Added `read` and `delete` permission checks to previously unprotected gRPC endpoints (`GetNeighbors`, `Search`, `SparqlQuery`, etc.).
2.  **MCP Hardening**: Integrated `jsonschema` validation to ensure all MCP tool calls match their defined schemas.
3.  **Graph Traversal**: Added `node_type_filter` to `NodeRequest` to allow filtering neighbors by their RDF type during traversal.
4.  **UX**: Added a CLI ASCII banner (suppressed in MCP mode).

Verified with new integration tests covering auth failures and node type filtering.

---
*PR created automatically by Jules for task [10791649575115757822](https://jules.google.com/task/10791649575115757822) started by @pmaojo*