### PR TITLE
Refactor: Extract NeighborExplorer and fix deterministic degree scoring

### DIFF
--- a/crates/semantic-engine/src/domain/constants.rs
+++ b/crates/semantic-engine/src/domain/constants.rs
@@ -1,0 +1,19 @@
+/// Weight decay for scores when expanding the graph during hybrid search.
+pub const GRAPH_EXPANSION_DECAY: f32 = 0.8;
+
+/// Base score for a node found at the direct starting point.
+pub const BASE_PATH_SCORE: f32 = 1.0;
+
+/// Default character length for text chunks during ingestion.
+pub const DEFAULT_CHUNK_SIZE: usize = 1000;
+
+/// Default overlap for text chunks.
+pub const DEFAULT_CHUNK_OVERLAP: usize = 150;
+
+/// Ontology Prefixes
+pub const SYS_ONTOLOGY_BASE: &str = "http://sys.semantic/core#";
+pub const FRONTEND_ONTOLOGY_BASE: &str = "http://sys.semantic/frontend#";
+pub const PROV_WAS_DERIVED_FROM: &str = "http://www.w3.org/ns/prov#wasDerivedFrom";
+pub const PROV_GENERATED_AT_TIME: &str = "http://www.w3.org/ns/prov#generatedAtTime";
+pub const PROV_WAS_GENERATED_BY: &str = "http://www.w3.org/ns/prov#wasGeneratedBy";
+pub const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";

--- a/crates/semantic-engine/src/domain/explorer_types.rs
+++ b/crates/semantic-engine/src/domain/explorer_types.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExplorerOptions {
+    pub namespace: String,
+    pub node_id: u32,
+    pub depth: usize,
+    pub direction: ExplorerDirection,
+    pub scoring_strategy: ScoringStrategy,
+    pub edge_filter: Option<String>,
+    pub node_type_filter: Option<String>,
+    pub limit_per_layer: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ExplorerDirection {
+    Outgoing,
+    Incoming,
+    Both,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ScoringStrategy {
+    Path,
+    Degree,
+}
+
+impl ExplorerDirection {
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "incoming" => Self::Incoming,
+            "both" => Self::Both,
+            _ => Self::Outgoing,
+        }
+    }
+
+    pub fn is_outgoing(&self) -> bool {
+        matches!(self, Self::Outgoing | Self::Both)
+    }
+
+    pub fn is_incoming(&self) -> bool {
+        matches!(self, Self::Incoming | Self::Both)
+    }
+}
+
+impl ScoringStrategy {
+    pub fn from_str(s: &str) -> Self {
+        match s.to_lowercase().as_str() {
+            "degree" => Self::Degree,
+            _ => Self::Path,
+        }
+    }
+}

--- a/crates/semantic-engine/src/domain/mod.rs
+++ b/crates/semantic-engine/src/domain/mod.rs
@@ -1,0 +1,3 @@
+pub mod constants;
+pub mod explorer_types;
+pub mod neighbor_explorer;

--- a/crates/semantic-engine/src/domain/neighbor_explorer.rs
+++ b/crates/semantic-engine/src/domain/neighbor_explorer.rs
@@ -1,0 +1,205 @@
+use crate::domain::explorer_types::{ExplorerOptions, ScoringStrategy};
+use crate::server::proto::Neighbor;
+use crate::store::SynapseStore;
+use std::collections::{HashSet, VecDeque};
+use std::sync::Arc;
+
+pub struct NeighborExplorer {
+    store: Arc<SynapseStore>,
+}
+
+impl NeighborExplorer {
+    pub fn new(store: Arc<SynapseStore>) -> Self {
+        Self { store }
+    }
+
+    pub async fn explore(&self, options: ExplorerOptions) -> Vec<Neighbor> {
+        let mut neighbors = Vec::new();
+        let mut visited = HashSet::new();
+        let mut queue = VecDeque::new();
+
+        // Start with the initial node
+        if let Some(start_uri) = self.store.get_uri(options.node_id) {
+            queue.push_back((start_uri.clone(), 0));
+            visited.insert(start_uri);
+        }
+
+        while let Some((current_uri, current_depth)) = queue.pop_front() {
+            if current_depth >= options.depth {
+                continue;
+            }
+
+            let next_depth = current_depth + 1;
+            let base_score = 1.0 / next_depth as f32;
+
+            let mut layer_count = 0;
+
+            // Query outgoing
+            if options.direction.is_outgoing() {
+                self.query_direction(
+                    &current_uri,
+                    true,
+                    &options,
+                    next_depth,
+                    base_score,
+                    &mut visited,
+                    &mut neighbors,
+                    &mut queue,
+                    &mut layer_count,
+                );
+            }
+
+            // Query incoming
+            if options.direction.is_incoming() {
+                self.query_direction(
+                    &current_uri,
+                    false,
+                    &options,
+                    next_depth,
+                    base_score,
+                    &mut visited,
+                    &mut neighbors,
+                    &mut queue,
+                    &mut layer_count,
+                );
+            }
+        }
+
+        // Sort by score (highest first)
+        neighbors.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        neighbors
+    }
+
+    fn query_direction(
+        &self,
+        uri: &str,
+        is_outgoing: bool,
+        options: &ExplorerOptions,
+        depth: usize,
+        base_score: f32,
+        visited: &mut HashSet<String>,
+        neighbors: &mut Vec<Neighbor>,
+        queue: &mut VecDeque<(String, usize)>,
+        layer_count: &mut usize,
+    ) {
+        if *layer_count >= options.limit_per_layer && options.limit_per_layer > 0 {
+            return;
+        }
+
+        let pattern = if is_outgoing {
+            (
+                oxigraph::model::NamedNodeRef::new(uri)
+                    .ok()
+                    .map(|n| n.into()),
+                None,
+                None,
+                None,
+            )
+        } else {
+            (
+                None,
+                None,
+                oxigraph::model::NamedNodeRef::new(uri)
+                    .ok()
+                    .map(|n| n.into()),
+                None,
+            )
+        };
+
+        for quad in self
+            .store
+            .store
+            .quads_for_pattern(pattern.0, pattern.1, pattern.2, pattern.3)
+            .flatten()
+        {
+            if *layer_count >= options.limit_per_layer && options.limit_per_layer > 0 {
+                break;
+            }
+
+            let pred = quad.predicate.to_string();
+            if let Some(ref filter) = options.edge_filter {
+                if !pred.contains(filter) {
+                    continue;
+                }
+            }
+
+            let target_term = if is_outgoing {
+                quad.object
+            } else {
+                quad.subject.into()
+            };
+            let target_uri = target_term.to_string();
+
+            // Type filter logic
+            if let Some(ref type_filter) = options.node_type_filter {
+                if !self.matches_type(&target_term, type_filter) {
+                    continue;
+                }
+            }
+
+            if !visited.contains(&target_uri) {
+                visited.insert(target_uri.clone());
+                let target_id = self.store.get_or_create_id(&target_uri);
+
+                let mut score = base_score;
+                if options.scoring_strategy == ScoringStrategy::Degree {
+                    let clean_uri = match &target_term {
+                        oxigraph::model::Term::NamedNode(n) => n.as_str(),
+                        _ => &target_uri,
+                    };
+                    let degree = self.store.get_degree(clean_uri);
+                    if degree > 0 {
+                        // Progressive penalty to ensure deterministic ranking:
+                        // degree 1 -> 1.0, degree 2 -> 1.41, degree 3 -> 1.73
+                        score /= (degree as f32).sqrt();
+                    }
+                }
+
+                neighbors.push(Neighbor {
+                    node_id: target_id,
+                    edge_type: pred,
+                    uri: target_uri.clone(),
+                    direction: if is_outgoing {
+                        "outgoing".to_string()
+                    } else {
+                        "incoming".to_string()
+                    },
+                    depth: depth as u32,
+                    score,
+                });
+                queue.push_back((target_uri, depth));
+                *layer_count += 1;
+            }
+        }
+    }
+
+    fn matches_type(&self, term: &oxigraph::model::Term, type_uri: &str) -> bool {
+        if let oxigraph::model::Term::NamedNode(ref n) = term {
+            let rdf_type = oxigraph::model::NamedNodeRef::new(
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+            )
+            .unwrap();
+            if let Ok(target_type) = oxigraph::model::NamedNodeRef::new(type_uri) {
+                self.store
+                    .store
+                    .quads_for_pattern(
+                        Some(n.into()),
+                        Some(rdf_type),
+                        Some(target_type.into()),
+                        None,
+                    )
+                    .next()
+                    .is_some()
+            } else {
+                false
+            }
+        } else {
+            false
+        }
+    }
+}

--- a/crates/semantic-engine/tests/server_test.rs
+++ b/crates/semantic-engine/tests/server_test.rs
@@ -1,0 +1,140 @@
+use std::env;
+use synapse_core::server::proto::semantic_engine_server::SemanticEngine;
+use synapse_core::server::proto::{IngestRequest, NodeRequest, Triple};
+use synapse_core::server::MySemanticEngine;
+use tonic::Request;
+
+#[tokio::test]
+async fn test_get_neighbors_deterministic_scoring() {
+    env::set_var("MOCK_EMBEDDINGS", "true");
+    env::set_var("SYNAPSE_AUTH_TOKENS", "{\"test-token\": [\"*\"]}");
+    let storage_path = "/tmp/synapse_test_neighbors";
+    let _ = std::fs::remove_dir_all(storage_path);
+
+    let engine = MySemanticEngine::new(storage_path);
+
+    // Setup Graph: A -> B, A -> C, C -> D
+    let triples = vec![
+        Triple {
+            subject: "http://a".into(),
+            predicate: "http://p".into(),
+            object: "http://b".into(),
+            provenance: None,
+            embedding: vec![],
+        },
+        Triple {
+            subject: "http://a".into(),
+            predicate: "http://p".into(),
+            object: "http://c".into(),
+            provenance: None,
+            embedding: vec![],
+        },
+        Triple {
+            subject: "http://c".into(),
+            predicate: "http://p".into(),
+            object: "http://d".into(),
+            provenance: None,
+            embedding: vec![],
+        },
+    ];
+
+    let mut ingest_req = Request::new(IngestRequest {
+        namespace: "test".into(),
+        triples,
+    });
+    ingest_req
+        .metadata_mut()
+        .insert("authorization", "Bearer test-token".parse().unwrap());
+    engine.ingest_triples(ingest_req).await.unwrap();
+
+    // 1. Resolve ID for "http://a"
+    let store = engine.get_store("test").unwrap();
+    let id_a = store.get_or_create_id("http://a");
+
+    // 2. Query Neighbors of A with strategy "degree"
+    let req = NodeRequest {
+        namespace: "test".into(),
+        node_id: id_a,
+        depth: 1,
+        direction: "outgoing".into(),
+        scoring_strategy: "degree".into(),
+        edge_filter: "".into(),
+        node_type_filter: "".into(),
+        limit_per_layer: 0,
+    };
+
+    let mut req_wrapped = Request::new(req);
+    req_wrapped
+        .metadata_mut()
+        .insert("authorization", "Bearer test-token".parse().unwrap());
+    let resp = engine
+        .get_neighbors(req_wrapped)
+        .await
+        .unwrap()
+        .into_inner();
+
+    // B should be first (lower degree than C which connects to D)
+    // Wait, let's verify degrees:
+    // B: 1 (incoming from A)
+    // C: 2 (incoming from A, outgoing to D)
+    // Current logic penalizes high degree. So B should have higher score than C.
+
+    assert_eq!(resp.neighbors.len(), 2);
+    for n in &resp.neighbors {
+        println!("Found neighbor: {} with score {}", n.uri, n.score);
+    }
+    let n_b = resp
+        .neighbors
+        .iter()
+        .find(|n| n.uri.contains("http://b"))
+        .unwrap();
+    let n_c = resp
+        .neighbors
+        .iter()
+        .find(|n| n.uri.contains("http://c"))
+        .unwrap();
+
+    assert!(
+        n_b.score > n_c.score,
+        "B (degree 1) should have higher score than C (degree 2). B: {}, C: {}",
+        n_b.score,
+        n_c.score
+    );
+
+    // 3. Query with depth 2
+    let req_depth = NodeRequest {
+        namespace: "test".into(),
+        node_id: id_a,
+        depth: 2,
+        direction: "outgoing".into(),
+        scoring_strategy: "path".into(),
+        edge_filter: "".into(),
+        node_type_filter: "".into(),
+        limit_per_layer: 0,
+    };
+
+    let mut req_depth_wrapped = Request::new(req_depth);
+    req_depth_wrapped
+        .metadata_mut()
+        .insert("authorization", "Bearer test-token".parse().unwrap());
+    let resp_depth = engine
+        .get_neighbors(req_depth_wrapped)
+        .await
+        .unwrap()
+        .into_inner();
+
+    // A -> B (depth 1)
+    // A -> C (depth 1)
+    // A -> C -> D (depth 2)
+    assert_eq!(resp_depth.neighbors.len(), 3);
+    let n_d = resp_depth
+        .neighbors
+        .iter()
+        .find(|n| n.uri.contains("http://d"))
+        .unwrap();
+    assert_eq!(n_d.depth, 2);
+    assert!(
+        n_b.score > n_d.score,
+        "Depth 1 node should have higher score than depth 2 node"
+    );
+}


### PR DESCRIPTION
This PR fixes a bug in scoring_strategy='degree' where nodes with different degrees were getting the same score. It also extracts the navigation logic into a separate NeighborExplorer class to align with G34 (Abstraction Levels).