### PR TITLE
Fix Crates.io Publishing Workflow and Bump Version

### DIFF
--- a/.github/workflows/publish-crates-io.yml
+++ b/.github/workflows/publish-crates-io.yml
@@ -3,6 +3,9 @@ name: Publish to Crates.io
 on:
   release:
     types: [published]
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3783,7 +3783,7 @@ dependencies = [
 
 [[package]]
 name = "synapse-core"
-version = "0.8.2"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.8.2"
+version = "0.8.4"
 edition = "2021"
 license = "MIT"
 authors = ["Grafoso Team"]

--- a/crates/semantic-engine/Cargo.toml
+++ b/crates/semantic-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "synapse-core"
-version = "0.8.2"
+version = "0.8.4"
 edition.workspace = true
 description = "A neuro-symbolic semantic engine for OpenClaw, combining graph databases with vector operations."
 readme = "README.md"

--- a/crates/semantic-engine/README.md
+++ b/crates/semantic-engine/README.md
@@ -44,7 +44,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-synapse-core = "0.2.0"
+synapse-core = "0.8.4"
 ```
 
 ### As a Binary


### PR DESCRIPTION
This PR fixes the issue where the crate was not being published to crates.io because the workflow only triggered on GitHub Release publication. It now triggers on tag pushes as well. Additionally, the version has been bumped to 0.8.4 to ensure a clean release, as v0.8.3 tag already existed. Documentation and lockfiles have been updated accordingly.

---
*PR created automatically by Jules for task [11619965535999232185](https://jules.google.com/task/11619965535999232185) started by @pmaojo*