### PR TITLE
feat(mcp): implement semantic os macro tools and cache layer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2264,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "synapse-core"
-version = "0.9.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/semantic-engine/src/ingest/mod.rs
+++ b/crates/semantic-engine/src/ingest/mod.rs
@@ -21,27 +21,53 @@ impl IngestionEngine {
             .unwrap_or("")
             .to_lowercase();
 
-        match extension.as_str() {
-            "md" | "markdown" => self.ingest_markdown(path).await,
+        let res = match extension.as_str() {
+            "md" | "markdown" => self.ingest_markdown(path, namespace).await,
             "csv" => self.ingest_csv(path, namespace).await,
             "owl" | "ttl" | "rdf" | "xml" => {
                 let count = ontology::OntologyLoader::load_file(&self.store, path).await?;
                 Ok(count as u32)
             }
             _ => Err(anyhow::anyhow!("Unsupported file type: {}", extension)),
+        };
+
+        if res.is_ok() {
+            if let Err(e) = self.generate_cache_digest() {
+                eprintln!("Warning: Failed to generate cache digest: {}", e);
+            }
         }
+
+        res
     }
 
-    async fn ingest_markdown(&self, path: &Path) -> Result<u32> {
+    async fn ingest_markdown(&self, path: &Path, role: &str) -> Result<u32> {
         use crate::md_sync::parser::MarkdownDocument;
+        use oxigraph::model::{NamedNode, Quad, Subject, Term, GraphName};
         let content = std::fs::read_to_string(path)?;
 
         let doc = MarkdownDocument::parse(path, &content)?;
         let quads = doc.to_quads();
         let mut added = 0;
 
+        let p_role = NamedNode::new("http://www.w3.org/ns/prov#Role").unwrap();
+
         for quad in quads {
-            if self.store.store.insert(&quad)? {
+            let modified_quad = quad.clone();
+            // If the ingest request specified an elevated role (e.g. CoreSpecification), we inject it
+            if role != "default" {
+                if let GraphName::NamedNode(batch_node) = &quad.graph_name {
+                    let o_role = Term::Literal(oxigraph::model::Literal::new_simple_literal(role));
+                    let role_quad = Quad::new(
+                        Subject::NamedNode(batch_node.clone()),
+                        p_role.clone(),
+                        o_role,
+                        GraphName::DefaultGraph
+                    );
+                    let _ = self.store.store.insert(&role_quad);
+                }
+            }
+
+            if self.store.store.insert(&modified_quad)? {
                 added += 1;
             }
         }
@@ -84,5 +110,52 @@ impl IngestionEngine {
 
         let (added, _) = self.store.ingest_triples(triples).await?;
         Ok(added)
+    }
+
+    fn generate_cache_digest(&self) -> Result<()> {
+        let query = "
+            PREFIX prov: <http://www.w3.org/ns/prov#>
+            PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+
+            SELECT ?s ?time (COUNT(?p) as ?density)
+            WHERE {
+                GRAPH ?g {
+                    ?s ?p ?o .
+                    ?g prov:generatedAtTime ?time .
+                }
+            }
+            GROUP BY ?s ?time
+            ORDER BY DESC(?time) DESC(?density)
+            LIMIT 5
+        ";
+
+        let result = self.store.query_sparql(query)?;
+        let mut content = String::from("# Synapse Semantic Cache Digest\n\n_Auto-generated \"Morning Briefing\" of recent hot paths._\n\n## Most Recently Modified Entities:\n");
+
+        if let Ok(json_res) = serde_json::from_str::<serde_json::Value>(&result) {
+            if let serde_json::Value::Array(arr) = json_res {
+                if arr.is_empty() {
+                    content.push_str("No recent activity found.\n");
+                } else {
+                    for row in arr {
+                        let s = row.get("s").and_then(|v| v.as_str()).unwrap_or("Unknown").trim_matches('"');
+                        let time = row.get("time").and_then(|v| v.as_str()).unwrap_or("Unknown").trim_matches('"');
+                        let density = row.get("density").and_then(|v| v.as_str()).unwrap_or("0").trim_matches('"');
+
+                        // Try to get type or name if possible, simplified for the digest
+                        content.push_str(&format!("* **{}** (Edges: {}, Last Modified: {})\n", s, density, time));
+                    }
+                }
+            }
+        } else {
+            content.push_str("Error parsing SPARQL results.\n");
+        }
+
+        let synapse_dir = Path::new(".synapse/state");
+        std::fs::create_dir_all(synapse_dir)?;
+        let digest_path = synapse_dir.join("current_digest.md");
+        std::fs::write(&digest_path, content)?;
+
+        Ok(())
     }
 }

--- a/crates/semantic-engine/src/ingest/mod.rs
+++ b/crates/semantic-engine/src/ingest/mod.rs
@@ -121,8 +121,8 @@ impl IngestionEngine {
             WHERE {
                 GRAPH ?g {
                     ?s ?p ?o .
-                    ?g prov:generatedAtTime ?time .
                 }
+                ?g prov:generatedAtTime ?time .
             }
             GROUP BY ?s ?time
             ORDER BY DESC(?time) DESC(?density)

--- a/crates/semantic-engine/src/mcp/tools.rs
+++ b/crates/semantic-engine/src/mcp/tools.rs
@@ -11,14 +11,48 @@ pub async fn handle_tool_call(
         "tools/list" => Ok(json!({
             "tools": [
                 {
-                    "name": "sparql_query",
-                    "description": "Execute a SPARQL query against the symbolic knowledge graph.",
+                    "name": "get_entity_narrative",
+                    "description": "Fetch a distilled Markdown summary (dossier) of an entity, including its identity, attributes, and key relationships.",
                     "inputSchema": {
                         "type": "object",
                         "properties": {
-                            "query": { "type": "string" }
+                            "entity_id": { "type": "string" }
                         },
-                        "required": ["query"]
+                        "required": ["entity_id"]
+                    }
+                },
+                {
+                    "name": "get_domain_logic",
+                    "description": "Fetch all entities and relationships bounded by a specific domain's aggregate root.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "slice_name": { "type": "string" }
+                        },
+                        "required": ["slice_name"]
+                    }
+                },
+                {
+                    "name": "get_dependency_impact",
+                    "description": "Traverse structural dependencies up to a bounded depth to determine the impact of a component.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "component_name": { "type": "string" },
+                            "depth": { "type": "number", "default": 1 }
+                        },
+                        "required": ["component_name"]
+                    }
+                },
+                {
+                    "name": "sync_specification_to_graph",
+                    "description": "Ingest a markdown file as a Core Specification, granting it elevated truth status.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "spec_file_path": { "type": "string" }
+                        },
+                        "required": ["spec_file_path"]
                     }
                 },
                 {
@@ -43,6 +77,28 @@ pub async fn handle_tool_call(
                         },
                         "required": ["directory_path"]
                     }
+                },
+                {
+                    "name": "sparql_query",
+                    "description": "[Graph Admin Only] Execute a raw SPARQL query. Use this only for debugging or if semantic macros fail.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": { "type": "string" }
+                        },
+                        "required": ["query"]
+                    }
+                },
+                {
+                    "name": "get_provenance",
+                    "description": "Fetch the full provenance trace for a specific provenance hash snippet.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "hash": { "type": "string" }
+                        },
+                        "required": ["hash"]
+                    }
                 }
             ]
         })),
@@ -62,6 +118,232 @@ pub async fn handle_tool_call(
                         })),
                         Err(e) => Err(format!("SPARQL Error: {}", e)),
                     }
+                }
+                "get_provenance" => {
+                    let hash = args["hash"].as_str().ok_or("Missing hash")?;
+                    let hash_str = if hash.starts_with("urn:batch:") {
+                        hash.to_string()
+                    } else {
+                        format!("urn:batch:{}", hash)
+                    };
+
+                    // Use FILTER(STRSTARTS) to handle truncated hashes correctly
+                    let query = format!("
+                        PREFIX prov: <http://www.w3.org/ns/prov#>
+                        SELECT ?graph ?p ?o
+                        WHERE {{
+                            GRAPH ?graph {{
+                                ?graph ?p ?o .
+                            }}
+                            FILTER(STRSTARTS(STR(?graph), \"{}\"))
+                        }}
+                    ", hash_str);
+
+                    match store.query_sparql(&query) {
+                        Ok(res) => Ok(json!({
+                            "content": [
+                                { "type": "text", "text": format!("Provenance Trace for {}:\n{}", hash, res) }
+                            ]
+                        })),
+                        Err(e) => Err(format!("SPARQL Error: {}", e)),
+                    }
+                }
+                "get_domain_logic" => {
+                    let slice_name = args["slice_name"].as_str().ok_or("Missing slice_name")?;
+                    let query = format!("
+                        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                        SELECT ?s ?p ?o
+                        WHERE {{
+                            ?s ?p ?o .
+                            ?s rdfs:subClassOf* <{}> .
+                        }}
+                    ", store.ensure_uri(slice_name));
+
+                    match store.query_sparql(&query) {
+                        Ok(res) => Ok(json!({
+                            "content": [
+                                { "type": "text", "text": format!("Domain Logic for {}:\n{}", slice_name, res) }
+                            ]
+                        })),
+                        Err(e) => Err(format!("SPARQL Error: {}", e)),
+                    }
+                }
+                "get_dependency_impact" => {
+                    let component_name = args["component_name"].as_str().ok_or("Missing component_name")?;
+                    let depth = args.get("depth").and_then(|v| v.as_u64()).unwrap_or(1);
+
+                    // Since dynamic depth and unbounded variable property paths (?p+) are invalid in standard SPARQL 1.1,
+                    // we simulate depth by executing a programmatic BFS locally or constructing explicit UNION blocks
+                    // For the sake of standard SPARQL compatibility, we construct a pattern of explicit depth joins up to the bound
+                    let mut union_blocks = Vec::new();
+
+                    for d in 1..=depth {
+                        let mut block = String::new();
+                        block.push_str(&format!("?s1 ?p1 <{}> . \n", store.ensure_uri(component_name)));
+                        if d > 1 {
+                            for i in 2..=d {
+                                block.push_str(&format!("?s{} ?p{} ?s{} . \n", i, i, i - 1));
+                            }
+                        }
+                        // Select the furthest subject and its property
+                        block.push_str(&format!("BIND(?s{} AS ?impacted_node)\n", d));
+                        union_blocks.push(format!("{{ {} }}", block));
+                    }
+
+                    let query = format!("
+                        SELECT DISTINCT ?impacted_node
+                        WHERE {{
+                            {}
+                        }}
+                    ", union_blocks.join(" UNION "));
+
+                    match store.query_sparql(&query) {
+                        Ok(res) => Ok(json!({
+                            "content": [
+                                { "type": "text", "text": format!("Dependency Impact for {} (depth {}):\n{}", component_name, depth, res) }
+                            ]
+                        })),
+                        Err(e) => Err(format!("SPARQL Error: {}", e)),
+                    }
+                }
+                "sync_specification_to_graph" => {
+                    use crate::ingest::IngestionEngine;
+                    let spec_file_path = args["spec_file_path"].as_str().ok_or("Missing spec_file_path")?;
+                    let engine = IngestionEngine::new(store.clone());
+
+                    let path = std::path::Path::new(spec_file_path);
+                    if path.is_file() {
+                        match engine.ingest_file(path, "CoreSpecification").await {
+                            Ok(count) => Ok(json!({
+                                "content": [
+                                    { "type": "text", "text": format!("Successfully ingested {} new triples from specification file {}", count, spec_file_path) }
+                                ]
+                            })),
+                            Err(e) => Err(format!("Failed to index file {}: {}", path.display(), e)),
+                        }
+                    } else {
+                        Err(format!("File not found: {}", spec_file_path))
+                    }
+                }
+                "get_entity_narrative" => {
+                    let entity_id = args["entity_id"].as_str().ok_or("Missing entity_id")?;
+                    // We add ORDER BY ?time DESC to get adaptive context window based on recency
+                    let query = format!("
+                        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                        PREFIX prov: <http://www.w3.org/ns/prov#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+                        SELECT ?p ?o ?g ?time
+                        WHERE {{
+                            GRAPH ?g {{
+                                <{}> ?p ?o .
+                                OPTIONAL {{
+                                    ?g prov:generatedAtTime ?time .
+                                }}
+                            }}
+                        }}
+                        ORDER BY DESC(?time)
+                    ", store.ensure_uri(entity_id));
+
+                    let inbound_query = format!("
+                        PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+                        PREFIX prov: <http://www.w3.org/ns/prov#>
+                        PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+                        SELECT ?s ?p ?g ?time
+                        WHERE {{
+                            GRAPH ?g {{
+                                ?s ?p <{}> .
+                                OPTIONAL {{
+                                    ?g prov:generatedAtTime ?time .
+                                }}
+                            }}
+                        }}
+                        ORDER BY DESC(?time)
+                    ", store.ensure_uri(entity_id));
+
+                    let mut type_val = String::from("Unknown");
+                    let mut attributes = Vec::new();
+                    let mut outbound = Vec::new();
+                    let mut inbound = Vec::new();
+                    let mut recent_context = String::new();
+
+                    if let Ok(res_str) = store.query_sparql(&query) {
+                        if let Ok(res) = serde_json::from_str::<Value>(&res_str) {
+                            if let Value::Array(arr) = res {
+                                for row in arr.iter().take(20) { // Limit to top 20 edges for context window
+                                    let p = row.get("p").and_then(|v| v.as_str()).unwrap_or("").trim_matches('"');
+                                    let o = row.get("o").and_then(|v| v.as_str()).unwrap_or("");
+                                    let is_literal = o.starts_with('"');
+                                    let o_clean = o.trim_matches('"');
+                                    let time = row.get("time").and_then(|v| v.as_str()).unwrap_or("").trim_matches('"');
+                                    let g = row.get("g").and_then(|v| v.as_str()).unwrap_or("").trim_matches('"');
+
+                                    let prov_hash = if g.starts_with("urn:batch:") {
+                                        let hash_part = &g["urn:batch:".len()..];
+                                        let short_hash = if hash_part.len() > 8 { &hash_part[..8] } else { hash_part };
+                                        format!(" [Prov: {}]", short_hash)
+                                    } else {
+                                        String::new()
+                                    };
+
+                                    if p.ends_with("type") {
+                                        type_val = o_clean.to_string();
+                                    } else if is_literal {
+                                        attributes.push(format!("- **{}**: {}{}", p.split(&['/', '#'][..]).last().unwrap_or(p), o_clean, prov_hash));
+                                    } else {
+                                        outbound.push(format!("- **{}** -> {}{}", p.split(&['/', '#'][..]).last().unwrap_or(p), o_clean, prov_hash));
+                                    }
+
+                                    if time > recent_context.as_str() {
+                                        recent_context = time.to_string();
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    if let Ok(res_str) = store.query_sparql(&inbound_query) {
+                        if let Ok(res) = serde_json::from_str::<Value>(&res_str) {
+                            if let Value::Array(arr) = res {
+                                for row in arr.iter().take(20) { // Limit to top 20 edges for context window
+                                    let s = row.get("s").and_then(|v| v.as_str()).unwrap_or("").trim_matches('"');
+                                    let p = row.get("p").and_then(|v| v.as_str()).unwrap_or("").trim_matches('"');
+                                    let time = row.get("time").and_then(|v| v.as_str()).unwrap_or("").trim_matches('"');
+                                    let g = row.get("g").and_then(|v| v.as_str()).unwrap_or("").trim_matches('"');
+
+                                    let prov_hash = if g.starts_with("urn:batch:") {
+                                        let hash_part = &g["urn:batch:".len()..];
+                                        let short_hash = if hash_part.len() > 8 { &hash_part[..8] } else { hash_part };
+                                        format!(" [Prov: {}]", short_hash)
+                                    } else {
+                                        String::new()
+                                    };
+
+                                    inbound.push(format!("- {} -> **{}**{}", s, p.split(&['/', '#'][..]).last().unwrap_or(p), prov_hash));
+                                    if time > recent_context.as_str() {
+                                        recent_context = time.to_string();
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    let narrative = format!(
+                        "# Dossier: {}\n\n**Identity**: {}\n\n### Attributes\n{}\n\n### Relationships\n#### Outbound (Relies On)\n{}\n\n#### Inbound (Depended Upon By)\n{}\n\n### Recent Context\nLatest Activity: {}",
+                        entity_id,
+                        type_val,
+                        if attributes.is_empty() { "None".to_string() } else { attributes.join("\n") },
+                        if outbound.is_empty() { "None".to_string() } else { outbound.join("\n") },
+                        if inbound.is_empty() { "None".to_string() } else { inbound.join("\n") },
+                        if recent_context.is_empty() { "Unknown" } else { &recent_context }
+                    );
+
+                    Ok(json!({
+                        "content": [
+                            { "type": "text", "text": narrative }
+                        ]
+                    }))
                 }
                 "get_entity_neighborhood" => {
                     let uri = args["uri"].as_str().ok_or("Missing uri")?;

--- a/crates/semantic-engine/src/mcp/tools.rs
+++ b/crates/semantic-engine/src/mcp/tools.rs
@@ -127,14 +127,13 @@ pub async fn handle_tool_call(
                         format!("urn:batch:{}", hash)
                     };
 
-                    // Use FILTER(STRSTARTS) to handle truncated hashes correctly
+                    // Use FILTER(STRSTARTS) to handle truncated hashes correctly.
+                    // Provenance triples are stored in the default graph for easy querying.
                     let query = format!("
                         PREFIX prov: <http://www.w3.org/ns/prov#>
                         SELECT ?graph ?p ?o
                         WHERE {{
-                            GRAPH ?graph {{
-                                ?graph ?p ?o .
-                            }}
+                            ?graph ?p ?o .
                             FILTER(STRSTARTS(STR(?graph), \"{}\"))
                         }}
                     ", hash_str);
@@ -228,6 +227,8 @@ pub async fn handle_tool_call(
                 "get_entity_narrative" => {
                     let entity_id = args["entity_id"].as_str().ok_or("Missing entity_id")?;
                     // We add ORDER BY ?time DESC to get adaptive context window based on recency
+                    // Core properties (like type) are stored in the default graph, so we query without GRAPH restriction,
+                    // and use OPTIONAL GRAPH to get provenance metadata if available.
                     let query = format!("
                         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
                         PREFIX prov: <http://www.w3.org/ns/prov#>
@@ -235,15 +236,14 @@ pub async fn handle_tool_call(
 
                         SELECT ?p ?o ?g ?time
                         WHERE {{
-                            GRAPH ?g {{
-                                <{}> ?p ?o .
-                                OPTIONAL {{
-                                    ?g prov:generatedAtTime ?time .
-                                }}
+                            <{}> ?p ?o .
+                            OPTIONAL {{
+                                GRAPH ?g {{ <{}> ?p ?o . }}
+                                ?g prov:generatedAtTime ?time .
                             }}
                         }}
                         ORDER BY DESC(?time)
-                    ", store.ensure_uri(entity_id));
+                    ", store.ensure_uri(entity_id), store.ensure_uri(entity_id));
 
                     let inbound_query = format!("
                         PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -252,15 +252,14 @@ pub async fn handle_tool_call(
 
                         SELECT ?s ?p ?g ?time
                         WHERE {{
-                            GRAPH ?g {{
-                                ?s ?p <{}> .
-                                OPTIONAL {{
-                                    ?g prov:generatedAtTime ?time .
-                                }}
+                            ?s ?p <{}> .
+                            OPTIONAL {{
+                                GRAPH ?g {{ ?s ?p <{}> . }}
+                                ?g prov:generatedAtTime ?time .
                             }}
                         }}
                         ORDER BY DESC(?time)
-                    ", store.ensure_uri(entity_id));
+                    ", store.ensure_uri(entity_id), store.ensure_uri(entity_id));
 
                     let mut type_val = String::from("Unknown");
                     let mut attributes = Vec::new();


### PR DESCRIPTION
This PR transforms Synapse Engine into a "Semantic Operating System" to optimize token-to-utility ratio by introducing specialized macro-tools, adaptive context windows based on `prov:generatedAtTime`, and a Semantic Cache layer that outputs a morning digest to `.synapse/state/current_digest.md`. Raw SPARQL queries are now relegated to debugging purposes.

---
*PR created automatically by Jules for task [1580128955937253910](https://jules.google.com/task/1580128955937253910) started by @pmaojo*